### PR TITLE
Improve reliability of resolving non-relative folder paths that cannot be resolved with require.resolve()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 module.exports = function(directory, recursive, regExp) {
-  var fs = require('fs')
   var dir = require('node-dir')
   var path = require('path')
 
-  var useRequireResolve = false
   // Assume absolute path by default
   var basepath = directory
 
@@ -13,11 +11,6 @@ module.exports = function(directory, recursive, regExp) {
   } else if (!path.isAbsolute(directory)) {
     // Module path
     basepath = require.resolve(directory)
-    useRequireResolve = true
-  }
-
-  if (!useRequireResolve) {
-    fs.accessSync(basepath, fs.F_OK);
   }
 
   var keys = dir


### PR DESCRIPTION
I discovered issues with require-context within Jest when using an absolute folder paths. In short, because the folder did not contain an `index.js`, `require.resolve()` threw an error.

This PR fixes this by detecting when `directory` is an absolute file path (according to `path.isAbsolute()`. In this case, we no longer use `require.resolve()`, since it may not be able to resolve the path for us if the folder doesn't contain an `index.js`. (Note that `node-dir` may still throw an error if `directory` doesn't exist.)

Additionally, I've switched to `path.join()` in two places instead of string concatenating with `path.sep` — admittedly a stylistic choice.