### PR TITLE
Fix corner-case problems when registered

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function(directory, recursive, regExp) {
   }
 
   context.resolve = function(key) {
-    return path.join(directory, key)
+    return path.join(basepath, key)
   }
 
   context.keys = function() {

--- a/register.js
+++ b/register.js
@@ -2,5 +2,5 @@ var wrap = module.constructor.wrap
 var requireContext = require('.')
 
 module.constructor.wrap = function(script) {
-  return wrap('require.context = ' + requireContext.toString() + '\n' + script)
+  return wrap('require.context = ' + requireContext.toString() + ';\n' + script)
 }


### PR DESCRIPTION
Fixes a problem when using just `"."` as the directory to require from.

Also fixes problems when requiring files from the `urijs` library (such as [`urijs/src/IPv6.js`](https://github.com/medialize/URI.js/blob/fa46615b9934217a971edd482b59b9f88303db00/src/IPv6.js)), since they begin with an IIFE created via `(function () {})()`.