### PR TITLE
Updating version reference for node-dir in package.json to use github…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/wilsonlewis/require-context#readme",
   "dependencies": {
-    "node-dir": "^0.1.17"
+    "node-dir": "fshost/node-dir#master"
   }
 }


### PR DESCRIPTION
… instead of npm.

This should bring in the updated code to fix the empty folder error.

https://github.com/wayou/node-dir/commit/a5cdb0e3c4973abb2bab57068fac206514e0760f

This should solve the issue reported [here](https://github.com/wilsonlewis/require-context/issues/5) which was caused by node-dir returning an "undefined" when meeting an empty folder. This wasn't fixed as of 0.1.17 but has been fixed with the latest commit to node-dir's master branch.